### PR TITLE
Update Javacord to 3.5.0

### DIFF
--- a/sdcf4j-javacord/pom.xml
+++ b/sdcf4j-javacord/pom.xml
@@ -70,13 +70,13 @@
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.5.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.5.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sdcf4j-javacord/src/main/java/de/btobastian/sdcf4j/handler/JavacordHandler.java
+++ b/sdcf4j-javacord/src/main/java/de/btobastian/sdcf4j/handler/JavacordHandler.java
@@ -24,7 +24,6 @@ import de.btobastian.sdcf4j.Sdcf4jMessage;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.Channel;
-import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.PrivateChannel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
@@ -192,8 +191,6 @@ public class JavacordHandler extends CommandHandler {
                 parameters[i] = api;
             } else if (type == Channel.class) {
                 parameters[i] = message.getChannel();
-            } else if (type == GroupChannel.class) {
-                parameters[i] = message.getChannel().asGroupChannel().orElse(null);
             } else if (type == PrivateChannel.class) {
                 parameters[i] = message.getChannel().asPrivateChannel().orElse(null);
             } else if (type == ServerChannel.class) {


### PR DESCRIPTION
The removed group channels in javacord caused the framework to be unusable since the class was missing.

What's your policy on version bumps? Does this warrant one?